### PR TITLE
Typo in build-deb7.sh + remove rm *.egg-info

### DIFF
--- a/build-deb7.sh
+++ b/build-deb7.sh
@@ -51,9 +51,9 @@ then
   sudo dpkg -i deb_dist/python3-${PROJECT}*.deb
 else
   echo Using Python 2
-	PATH=$CCPATH python setup.py --command-packages=stdeb.command bdist_deb --no-cython
+  PATH=$CCPATH python setup.py --command-packages=stdeb.command bdist_deb --no-cython
 fi
 
-sudo su -c  "dpkg -i deb_dist/${PROJECT}*.deb"
+sudo su -c  "dpkg -i deb_dist/python-${PROJECT}*.deb"
 cd ../..
 

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -32,7 +32,6 @@ override_dh_install:
 
 override_dh_auto_test:
 	dh_auto_test -- -s custom --test-args="env PYTHONPATH={build_dir} {interpreter} run_tests.py -i"
-	rm -rf *.egg-info
 
 #override_dh_installman:
 #	dh_installman -p silx doc/*.1


### PR DESCRIPTION
Tested on Debian 7 and 8
