### PR TITLE
Correct minor rst formatting issues causing sphinx warnings

### DIFF
--- a/doc/source/description/sift.rst
+++ b/doc/source/description/sift.rst
@@ -125,7 +125,7 @@ SIFT keypoints computation
 
 The keypoints are detected in several steps according to Lowe's paper_ :
 
-.. _paper: "http://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf"
+.. _paper: http://www.cs.ubc.ca/~lowe/papers/ijcv04.pdf
 
 * Keypoints detection: local extrema are detected in the *scale-space* :math:`(x, y, s)`.
   Every pixel is compared to its neighborhood in the image itself,
@@ -305,7 +305,6 @@ You should not modify these values unless you know what you are doing.
 Some parameters require to understand several aspects of the algorithm,
 explained in Lowe's original paper.
 
-.. _paper: www.cs.ubc.ca/~lowe/papers/ijcv04.pdf
 .. _ASIFT: http://www.ipol.im/pub/art/2011/my-asift
 
 

--- a/silx/image/sift/match.py
+++ b/silx/image/sift/match.py
@@ -308,7 +308,7 @@ class MatchPlan(object):
         """Defines the region of interest
 
         :param roi: region of interest as 2D numpy array with non zero where
-        valid pixels are.
+                    valid pixels are
         """
         with self._sem:
             self.roi = numpy.ascontiguousarray(roi, numpy.int8)


### PR DESCRIPTION
- unexpected unindent in set_roi parameter description
- duplicate link definition paper_
